### PR TITLE
add config options to match typescript-graphql-files-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ generates:
 ```
 <!-- AUTO-GENERATED-CONTENT:END -->
 
+The `apollo-typed-documents` plugin also accepts the same `modulePathPrefix`, `relativeToCwd` and `prefix` config settings as [typescript-graphql-files-modules](https://graphql-code-generator.com/docs/plugins/typescript-graphql-files-modules).
+
 `tsconfig.json`:
 
 Add `node_modules/apollo-typed-documents/lib/reactHooks.d.ts` in `include` to override the typings for `@apollo/react-hooks`, so that types can be inferred from typed documents.

--- a/src/__tests__/codegenTypedDocuments.test.ts
+++ b/src/__tests__/codegenTypedDocuments.test.ts
@@ -138,4 +138,119 @@ describe("codegenTypedDocuments", () => {
       }"
     `);
   });
+
+  describe("module path customization", () => {
+    const queryDocument = parse(`
+      query authors {
+        authors {
+          idField
+        }
+      }
+    `);
+
+    const mutationDocument = parse(`
+      mutation createAuthor {
+        createAuthor {
+          idField
+        }
+      }
+    `);
+
+    const documents = [
+      { document: queryDocument, location: "literary/types/authors.gql" },
+      { document: mutationDocument, location: "mutations/createAuthor.gql" },
+    ];
+
+    const getPathConfig = (pluginConfig: Record<string, unknown>) => {
+      return getConfig({
+        documents,
+        plugins: [
+          {
+            codegenTypedDocuments: {
+              typesModule: "@codegen-types",
+              ...pluginConfig,
+            },
+          },
+        ],
+      });
+    };
+
+    it("wildcards the basename by default", async () => {
+      const config = getPathConfig({});
+      const output = await codegen(config);
+
+      expect(output).toMatchInlineSnapshot(`
+        "declare module \\"*/authors.gql\\" {
+          import { TypedDocumentNode } from \\"apollo-typed-documents\\";
+          import { AuthorsQuery, AuthorsQueryVariables } from \\"@codegen-types\\";
+          export const authors: TypedDocumentNode<AuthorsQueryVariables, AuthorsQuery>;
+          export default authors;
+        }
+
+        declare module \\"*/createAuthor.gql\\" {
+          import { TypedDocumentNode } from \\"apollo-typed-documents\\";
+          import { CreateAuthorMutation, CreateAuthorMutationVariables } from \\"@codegen-types\\";
+          export const createAuthor: TypedDocumentNode<CreateAuthorMutationVariables, CreateAuthorMutation>;
+          export default createAuthor;
+        }"
+      `);
+    });
+
+    it("respects the relativeToCwd setting", async () => {
+      const config = getPathConfig({ relativeToCwd: true });
+      const output = await codegen(config);
+
+      expect(output).toEqual(
+        expect.stringContaining(`declare module "*/literary/types/authors.gql"`)
+      );
+      expect(output).toEqual(
+        expect.stringContaining(`declare module "*/mutations/createAuthor.gql"`)
+      );
+    });
+
+    it("respects the prefix setting", async () => {
+      const config = getPathConfig({ prefix: "gql/" });
+      const output = await codegen(config);
+
+      expect(output).toEqual(
+        expect.stringContaining(`declare module "gql/authors.gql"`)
+      );
+      expect(output).toEqual(
+        expect.stringContaining(`declare module "gql/createAuthor.gql"`)
+      );
+    });
+
+    it("even respects the superfluous modulePathPrefix setting", async () => {
+      const config = getPathConfig({ modulePathPrefix: "stuff/" });
+      const output = await codegen(config);
+
+      expect(output).toEqual(
+        expect.stringContaining(`declare module "*/stuff/authors.gql"`)
+      );
+      expect(output).toEqual(
+        expect.stringContaining(`declare module "*/stuff/createAuthor.gql"`)
+      );
+    });
+
+    it("allows combining path settings", async () => {
+      const config = getPathConfig({
+        prefix: "",
+        modulePathPrefix: "defs/",
+        relativeToCwd: true,
+      });
+
+      const output = await codegen(config);
+
+      expect(output).toEqual(
+        expect.stringContaining(
+          `declare module "defs/literary/types/authors.gql"`
+        )
+      );
+      expect(output).toEqual(
+        expect.stringContaining(
+          `declare module "defs/mutations/createAuthor.gql"`
+        )
+      );
+    });
+  });
 });

--- a/src/visitors/TypedDocumentVisitor.ts
+++ b/src/visitors/TypedDocumentVisitor.ts
@@ -1,7 +1,14 @@
+import { basename, relative } from "path";
+
 import { DefinitionNode, DocumentNode, OperationDefinitionNode } from "graphql";
 import { pascalCase } from "pascal-case";
 
-export type Config = { typesModule: string };
+export type Config = {
+  typesModule: string;
+  modulePathPrefix: string;
+  useRelative: boolean;
+  prefix: string;
+};
 
 const isOperationDefinitionNode = (
   node: DefinitionNode
@@ -10,7 +17,7 @@ const isOperationDefinitionNode = (
 export default class TypedDocumentVisitor {
   constructor(
     readonly output: string[],
-    readonly basename: string,
+    readonly location: string,
     readonly config: Config
   ) {}
 
@@ -18,7 +25,13 @@ export default class TypedDocumentVisitor {
     const operationNodes = node.definitions.filter(isOperationDefinitionNode);
     const output: string[] = [];
 
-    output.push(`declare module "*/${this.basename}" {\n`);
+    const filepath = this.config.useRelative
+      ? relative(process.cwd(), this.location)
+      : basename(this.location);
+
+    const modulePath = `${this.config.prefix}${this.config.modulePathPrefix}${filepath}`;
+
+    output.push(`declare module "${modulePath}" {\n`);
     output.push(
       '  import { TypedDocumentNode } from "apollo-typed-documents";\n'
     );


### PR DESCRIPTION
Adds `modulePathPrefix`, `relativeToCwd`, and `prefix` config options so that this can be a bit more of a drop-in replacement for `typescript-graphql-files-modules`.

