### PR TITLE
Allow reserved word arguments

### DIFF
--- a/src/__tests__/codegenApolloMock.test.ts
+++ b/src/__tests__/codegenApolloMock.test.ts
@@ -1419,78 +1419,6 @@ describe("codegenApolloMock", () => {
   });
 
   describe("mutation", () => {
-    describe("with `delete` argument", () => {
-      const getTestConfig: GetTestConfig = () => {
-        const document = parse(`
-          mutation deleteAuthors($delete: [ID!]) {
-            deleteAuthors(delete: $delete)
-          }
-        `);
-
-        const documents = [{ document, location: "deleteAuthors.gql" }];
-
-        return [getConfig({ documents }), document];
-      };
-
-      it("should reference arguments named `delete` in a safe way", async () => {
-        const [config] = getTestConfig();
-        const output = await codegen(config);
-
-        expect(output).toBeTruthy();
-        expect(output).toMatchInlineSnapshot(`
-          "import { createApolloMock } from 'apollo-typed-documents';
-
-          const operations = {};
-
-          export default createApolloMock(operations);
-
-          operations.deleteAuthors = {};
-          operations.deleteAuthors.variables = (values = {}, options = {}) => {
-            const __typename = '';
-            values = (({ delete: __safe_delete__ = undefined }) => ({ delete: __safe_delete__ }))(values);
-            values.__typename = __typename;
-            return {
-              delete: values.delete
-            };
-          };
-          operations.deleteAuthors.data = (values = {}, options = {}) => {
-            const __typename = '';
-            values = (({ deleteAuthors = null }) => ({ deleteAuthors }))(values);
-            values.__typename = __typename;
-            return {
-              deleteAuthors: values.deleteAuthors
-            };
-          };"
-        `);
-      });
-
-      it("with arguments", async () => {
-        const [config, document] = getTestConfig();
-        const output = await codegen(config);
-        const apolloMock = getApolloMock(output);
-        const result = apolloMock(document, { delete: ["a", "b"] }, {});
-
-        expect(result).toMatchInlineSnapshot(`
-          {
-            "request": {
-              "query": "...",
-              "variables": {
-                "delete": [
-                  "a",
-                  "b"
-                ]
-              }
-            },
-            "result": {
-              "data": {
-                "deleteAuthors": null
-              }
-            }
-          }
-        `);
-      });
-    });
-
     describe("with minimal document", () => {
       const getTestConfig: GetTestConfig = () => {
         const document = parse(`
@@ -1770,6 +1698,78 @@ describe("codegenApolloMock", () => {
                   "idField": "Author-idField",
                   "__typename": "Author"
                 }
+              }
+            }
+          }
+        `);
+      });
+    });
+
+    describe("with JavaScript reserved keyword as argument", () => {
+      const getTestConfig: GetTestConfig = () => {
+        const document = parse(`
+          mutation deleteAuthors($delete: [ID!]) {
+            deleteAuthors(delete: $delete)
+          }
+        `);
+
+        const documents = [{ document, location: "deleteAuthors.gql" }];
+
+        return [getConfig({ documents }), document];
+      };
+
+      it("should reference argument in a safe way", async () => {
+        const [config] = getTestConfig();
+        const output = await codegen(config);
+
+        expect(output).toBeTruthy();
+        expect(output).toMatchInlineSnapshot(`
+          "import { createApolloMock } from 'apollo-typed-documents';
+
+          const operations = {};
+
+          export default createApolloMock(operations);
+
+          operations.deleteAuthors = {};
+          operations.deleteAuthors.variables = (values = {}, options = {}) => {
+            const __typename = '';
+            values = (({ delete: __safe_delete__ = undefined }) => ({ delete: __safe_delete__ }))(values);
+            values.__typename = __typename;
+            return {
+              delete: values.delete
+            };
+          };
+          operations.deleteAuthors.data = (values = {}, options = {}) => {
+            const __typename = '';
+            values = (({ deleteAuthors = null }) => ({ deleteAuthors }))(values);
+            values.__typename = __typename;
+            return {
+              deleteAuthors: values.deleteAuthors
+            };
+          };"
+        `);
+      });
+
+      it("with arguments", async () => {
+        const [config, document] = getTestConfig();
+        const output = await codegen(config);
+        const apolloMock = getApolloMock(output);
+        const result = apolloMock(document, { delete: ["a", "b"] }, {});
+
+        expect(result).toMatchInlineSnapshot(`
+          {
+            "request": {
+              "query": "...",
+              "variables": {
+                "delete": [
+                  "a",
+                  "b"
+                ]
+              }
+            },
+            "result": {
+              "data": {
+                "deleteAuthors": null
               }
             }
           }

--- a/src/visitors/MockVisitor.ts
+++ b/src/visitors/MockVisitor.ts
@@ -76,7 +76,7 @@ export default class MockVisitor {
     const fields = input ? field.inputFields : field.outputFields;
     const fieldNames = fields
       .filter((field) => !field.isFragment)
-      .map((field) => field.name);
+      .map((field) => field.safeName);
 
     output.push(" ".repeat(indent));
     output.push("values = (({ ");

--- a/src/visitors/MockVisitor.ts
+++ b/src/visitors/MockVisitor.ts
@@ -74,17 +74,21 @@ export default class MockVisitor {
 
     const defaultValue = input ? "undefined" : "null";
     const fields = input ? field.inputFields : field.outputFields;
-    const fieldNames = fields
+    const safelyReferencedFieldNames = fields
       .filter((field) => !field.isFragment)
-      .map((field) => field.safeName);
+      .map(({ name }) =>
+        RESERVED_JS_KEYWORDS.includes(name) ? `${name}: __safe_${name}__` : name
+      );
 
     output.push(" ".repeat(indent));
     output.push("values = (({ ");
     output.push(
-      fieldNames.map((name) => `${name} = ${defaultValue}`).join(", ")
+      safelyReferencedFieldNames
+        .map((name) => `${name} = ${defaultValue}`)
+        .join(", ")
     );
     output.push(" }) => ({ ");
-    output.push(fieldNames.join(", "));
+    output.push(safelyReferencedFieldNames.join(", "));
     output.push(" }))(values);\n");
 
     if (!field.isFragment) {
@@ -233,3 +237,52 @@ export default class MockVisitor {
     return output.join("");
   }
 }
+
+const RESERVED_JS_KEYWORDS = [
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "super",
+  "switch",
+  "static",
+  "this",
+  "throw",
+  "try",
+  "True",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+];

--- a/src/visitors/TypedVisitor.ts
+++ b/src/visitors/TypedVisitor.ts
@@ -35,7 +35,6 @@ export interface TypedField {
   isList: boolean;
   isFragment: boolean;
   isTypename: boolean;
-  safeName: string;
   typenames: string[];
 
   scalarType?: GraphQLScalarType;
@@ -50,75 +49,18 @@ export interface TypedOperationDefinitionNode extends OperationDefinitionNode {
   typed: TypedField;
 }
 
-const KEYWORDS = [
-  "await",
-  "break",
-  "case",
-  "catch",
-  "class",
-  "const",
-  "continue",
-  "debugger",
-  "default",
-  "delete",
-  "do",
-  "else",
-  "enum",
-  "export",
-  "extends",
-  "false",
-  "finally",
-  "for",
-  "function",
-  "if",
-  "implements",
-  "import",
-  "in",
-  "instanceof",
-  "interface",
-  "let",
-  "new",
-  "null",
-  "package",
-  "private",
-  "protected",
-  "public",
-  "return",
-  "super",
-  "switch",
-  "static",
-  "this",
-  "throw",
-  "try",
-  "True",
-  "typeof",
-  "var",
-  "void",
-  "while",
-  "with",
-  "yield",
-];
-
-const getSafeName = (name: string) =>
-  KEYWORDS.includes(name) ? `${name}: __safe_${name}__` : name;
-
 const createTypedField = (
   field: Partial<TypedField> & { name: string }
-): TypedField => {
-  const safeName = getSafeName(field.name);
-
-  return {
-    inputFields: [],
-    outputFields: [],
-    isNonNull: false,
-    isList: false,
-    isFragment: false,
-    isTypename: false,
-    safeName,
-    typenames: [],
-    ...field,
-  };
-};
+): TypedField => ({
+  inputFields: [],
+  outputFields: [],
+  isNonNull: false,
+  isList: false,
+  isFragment: false,
+  isTypename: false,
+  typenames: [],
+  ...field,
+});
 
 const isFragmentDefinitionNode = (
   node: DefinitionNode

--- a/src/visitors/TypedVisitor.ts
+++ b/src/visitors/TypedVisitor.ts
@@ -35,6 +35,7 @@ export interface TypedField {
   isList: boolean;
   isFragment: boolean;
   isTypename: boolean;
+  safeName: string;
   typenames: string[];
 
   scalarType?: GraphQLScalarType;
@@ -49,18 +50,75 @@ export interface TypedOperationDefinitionNode extends OperationDefinitionNode {
   typed: TypedField;
 }
 
+const KEYWORDS = [
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "super",
+  "switch",
+  "static",
+  "this",
+  "throw",
+  "try",
+  "True",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+];
+
+const getSafeName = (name: string) =>
+  KEYWORDS.includes(name) ? `${name}: __safe_${name}__` : name;
+
 const createTypedField = (
   field: Partial<TypedField> & { name: string }
-): TypedField => ({
-  inputFields: [],
-  outputFields: [],
-  isNonNull: false,
-  isList: false,
-  isFragment: false,
-  isTypename: false,
-  typenames: [],
-  ...field,
-});
+): TypedField => {
+  const safeName = getSafeName(field.name);
+
+  return {
+    inputFields: [],
+    outputFields: [],
+    isNonNull: false,
+    isList: false,
+    isFragment: false,
+    isTypename: false,
+    safeName,
+    typenames: [],
+    ...field,
+  };
+};
 
 const isFragmentDefinitionNode = (
   node: DefinitionNode


### PR DESCRIPTION
Addresses https://github.com/rubengrill/apollo-typed-documents/issues/56

When a graph Mutation has an argument that shares its name with a JavaScript reserved word (e.g. `delete` or `await`), the generated mocks will contain invalid syntax that corrupts the entire module.

This PR refers to those arguments with a safe name that allows the scripts to run successfully!

**Example**

```gql
// schema.gql
type Mutation {
  deleteAuthors(delete: [ID!]): [ID!]
}

// document.gql
mutation deleteAuthors($delete: [ID!]) {
  deleteAuthors(delete: $delete)
}
```

```js
// generated-mocks.js
operations.deleteAuthors = {};
operations.deleteAuthors.variables = (values = {}, options = {}) => {
  const __typename = '';
  values = (({ delete: __safe_delete__ = undefined }) => ({ delete: __safe_delete__ }))(values);
  //           ^^^^^^^^^^^^^^^^^^^^^^^                      ^^^^^^^^^^^^^^^^^^^^^^^
  values.__typename = __typename;
  return {
    delete: values.delete
  };
};
```